### PR TITLE
Automatic module name added

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -202,6 +202,18 @@
                     <goals>deploy</goals>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.3.0</version>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>com.offbynull.portmapper</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     <profiles>


### PR DESCRIPTION
`maven-jar-plugin` is used to add "Automatic-Module-Name" to `MANIFEST.MF` at buildtime. This is the minimum that is needed if you want to use the lib on the module path in a project.